### PR TITLE
fix: Adjust candidate management tab order

### DIFF
--- a/client/src/components/admin/AdminDashboard.js
+++ b/client/src/components/admin/AdminDashboard.js
@@ -308,10 +308,6 @@ const AdminDashboard = () => {
             </tbody>
           </Table>
         </Tab>
-        <Tab eventKey="stats" title="Estadísticas"><StatsDashboard /></Tab>
-        <Tab eventKey="assignTokens" title="Asignar Tokens"><AssignTokens users={users} /></Tab>
-        <Tab eventKey="stats" title="Estadísticas"><StatsDashboard /></Tab>
-        <Tab eventKey="assignTokens" title="Asignar Tokens"><AssignTokens users={users} /></Tab>
         <Tab eventKey="candidates" title="Gestionar Candidatos">
           <ManageCandidates
             isElectionActive={isElectionActive}
@@ -319,6 +315,9 @@ const AdminDashboard = () => {
             allElections={elections}
           />
         </Tab>
+        <Tab eventKey="stats" title="Estadísticas"><StatsDashboard /></Tab>
+        <Tab eventKey="assignTokens" title="Asignar Tokens"><AssignTokens users={users} /></Tab>
+      </Tabs>
 
       {/* Create Election Modal */}
       <Modal show={showCreateElectionModal} onHide={() => setShowCreateElectionModal(false)}>


### PR DESCRIPTION
This commit moves the "Gestionar Candidatos" tab to be the third tab in the AdminDashboard, appearing after "Elecciones" and before "Estadísticas", as per your feedback.